### PR TITLE
Upgrade Facebook Versions

### DIFF
--- a/application/src/main/java/com/sanction/lightning/facebook/FacebookService.java
+++ b/application/src/main/java/com/sanction/lightning/facebook/FacebookService.java
@@ -156,7 +156,7 @@ public class FacebookService {
           return null;
       }
     } catch (FacebookException e) {
-      LOG.error("Unknown error while publishing to Facebook.");
+      LOG.error("Unknown error while publishing to Facebook.", e);
       return null;
     }
 
@@ -198,7 +198,8 @@ public class FacebookService {
         .addPermission(UserDataPermissions.USER_ACTIONS_VIDEO)
         .addPermission(ExtendedPermissions.PUBLISH_ACTIONS);
 
-    return client.getLoginDialogUrl(appId, redirectUrl, scopeBuilder);
+    return client.getLoginDialogUrl(appId, redirectUrl, scopeBuilder,
+        Parameter.with("response_type", "token"));
   }
 
   /**

--- a/application/src/main/java/com/sanction/lightning/facebook/FacebookService.java
+++ b/application/src/main/java/com/sanction/lightning/facebook/FacebookService.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
 
 public class FacebookService {
   private static final Logger LOG = LoggerFactory.getLogger(FacebookService.class);
-  private static final Version VERSION = Version.VERSION_2_4;
+  private static final Version VERSION = Version.VERSION_2_10;
 
   private final DefaultFacebookClient client;
   private final String appId;

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <guava.version>21.0</guava.version>
     <thunder.version>0.5.0</thunder.version>
     <twitter4j.version>4.0.6</twitter4j.version>
-    <restfb.version>1.14.1</restfb.version>
+    <restfb.version>1.45.0</restfb.version>
     <jackson.api.version>2.7.8</jackson.api.version>
     <jacoco.version>0.7.9</jacoco.version>
     <junit.version>4.12</junit.version>

--- a/scripts/tester.py
+++ b/scripts/tester.py
@@ -102,7 +102,8 @@ if __name__ == '__main__':
     # Define test cases
     all_tests = [
         # Facebook
-        TestCase('GET', '/facebook/oauthUrl', authentication),
+        TestCase('GET', '/facebook/oauthUrl', authentication,
+                 params={'redirect': 'sample://url'}),
         TestCase('GET', '/facebook/users', authentication,
                  params={'email': args.email},
                  headers={'password': password}),


### PR DESCRIPTION
- Upgrade RestFB to v1.45.0
- Upgrade Facebook Graph API to v2.10
- Adds a parameter to the OAuth URL to get the correct one

Addresses #26 