### PR TITLE
Move Facebook OAuth Exceptions to Service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ jdk:
 install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V --settings settings.xml
 script: mvn clean test jacoco:report coveralls:report
 
+branches:
+  only:
+    - master
+
 env:
   global:
     - secure: NCc5+WGnxpadS397/+kC9iUOULbP/TD9+37VzoBbLLLmOzEbaqJstLoVlugPOtt0yxqxPUCywjg37tMorM87MRwGbS5eWpKS6dMyLNDRdIhyMGAAFcb29DNTxFFQVvdYhyCvjnAgnaAX2NSkBpMgDL1BlqgdscGnuZPtoaFCJX8g82Y5IdBSlBoOvvVChwB1GWKoz2j+ooBD7WA2i89cbe6PQKqJI7XaetUb5whLJOkUunb2SMCK7ew3z6vBsXaP/3VVIzOYG6gGW4VxfBd28DCAOUEsaLAmPzNjZJ70u9L+zJlqQwJ3E2F9Anq6pb8n3Cl7V+S/iMloMYkqc10Ialke1evMyLgS+OaHr+8GZUTWhxWvkiZ/TWNLsgeQ8kUF9Bcxyfl6ran2lqXZFv4AKlchUIk6o/G3vvlEtfaCQq8OnzeyN2wTnFCHomQbfM0HOTXktQCB4e2i7MsltmNYQEv1WaxniiYiLPPsILKi9rdqWOy6gWQ0JLrWCS+eg2dffGdhlKruzthtGCrUgBYqdkajgxUgShIxA3y9/FBhEzz9fFShdzTY6yFrePYqVBWxrEYmjyMgLmg7kFJ7tObzvan2jW+BwIvmbcygJ9MH0vO4vG0Wj5fvfn7IVz7qS1dvChhPoBZcnmNNTKhd7aa6Xt+CXwV330wuoDvygJWITIc=

--- a/application/src/main/java/com/sanction/lightning/facebook/FacebookService.java
+++ b/application/src/main/java/com/sanction/lightning/facebook/FacebookService.java
@@ -69,8 +69,13 @@ public class FacebookService {
    * @return A FacebookUser object containing the user's information.
    */
   public FacebookUser getFacebookUser() {
-    return client.fetchObject("me", FacebookUser.class,
-        Parameter.with("fields", "first_name, last_name, middle_name, gender, name, verified"));
+    try {
+      return client.fetchObject("me", FacebookUser.class,
+          Parameter.with("fields", "first_name, last_name, middle_name, gender, name, verified"));
+    } catch (FacebookOAuthException e) {
+      LOG.error("Facebook OAuth error while getting user details.", e);
+      return null;
+    }
   }
 
   /**
@@ -81,27 +86,67 @@ public class FacebookService {
    */
   public List<FacebookPhoto> getFacebookUserPhotos() {
     // Fetch a JSON object containing an array of photos, each with specified properties
-    JsonObject photos = client.fetchObject("me/photos", JsonObject.class,
-            Parameter.with("type", "uploaded"), Parameter.with("fields", "id, images"));
+    JsonObject photos;
 
-    // Fetch the photo array from JsonObject and make a JsonArray
+    try {
+      photos = client.fetchObject("me/photos", JsonObject.class,
+          Parameter.with("type", "uploaded"), Parameter.with("fields", "id, images"));
+    } catch (FacebookOAuthException e) {
+      LOG.error("Facebook OAuth error while getting user photos.", e);
+      return null;
+    }
+
+    // Get the data from the JsonObject
     JsonArray photosArray = photos.getJsonArray("data");
-
     List<FacebookPhoto> photoList = Lists.newArrayList();
 
-    // Construct a JsonMapper for JSON string to FacebookPhotoDetail conversion
+    // JSON string to FacebookPhotoDetail conversion
     DefaultJsonMapper mapper = new DefaultJsonMapper();
+
     for (int i = 0; i < photosArray.length(); i++) {
       JsonObject obj = photosArray.getJsonObject(i);
+
       List<FacebookPhotoDetail> detailList = mapper.toJavaList(obj.getString("images"),
           FacebookPhotoDetail.class);
       FacebookPhotoDetail detail = detailList.get(0);
-      FacebookPhoto pic = new FacebookPhoto(obj.getString("id"), detail.getUri(),
+
+      FacebookPhoto photo = new FacebookPhoto(obj.getString("id"), detail.getUri(),
           detail.getHeight(), detail.getWidth());
-      photoList.add(pic);
+      photoList.add(photo);
     }
 
     return photoList;
+  }
+
+  /**
+   * Retrieves the authenticating user's Facebook videos.
+   * This method does not download the actual video bytes.
+   *
+   * @return A list of FacebookVideo objects representing the user's videos.
+   */
+  public List<FacebookVideo> getFacebookUserVideos() {
+    JsonObject videos;
+
+    try {
+      videos = client.fetchObject("me/videos", JsonObject.class,
+          Parameter.with("type", "uploaded"),
+          Parameter.with("fields", "id, source"));
+    } catch (FacebookOAuthException e) {
+      LOG.error("Facebook OAuth error while getting user videos.", e);
+      return null;
+    }
+
+    JsonArray videoArray = videos.getJsonArray("data");
+    List<FacebookVideo> videoList = Lists.newArrayList();
+
+    for (int i = 0; i < videoArray.length() - 1; i++) {
+      JsonObject obj = videoArray.getJsonObject(i);
+
+      FacebookVideo vid = new FacebookVideo(obj.getString("id"), obj.getString("source"));
+      videoList.add(vid);
+    }
+
+    return videoList;
   }
 
   /**
@@ -157,7 +202,7 @@ public class FacebookService {
           return null;
       }
     } catch (FacebookOAuthException e) {
-      LOG.error("Current user could not authenticate with Facebook.", e);
+      LOG.error("Facebook OAuth error while publishing.", e);
       return null;
     } catch (FacebookException e) {
       LOG.error("Unknown error while publishing to Facebook.", e);
@@ -165,36 +210,6 @@ public class FacebookService {
     }
 
     return response.toString();
-  }
-
-  /**
-   * Retrieves the authenticating user's Facebook videos.
-   * This method does not download the actual video bytes.
-   *
-   * @return A list of FacebookVideo objects representing the user's videos.
-   */
-  public List<FacebookVideo> getFacebookUserVideos() {
-    JsonObject videos;
-
-    try {
-      videos = client.fetchObject("me/videos", JsonObject.class,
-          Parameter.with("type", "uploaded"),
-          Parameter.with("fields", "id, source"));
-    } catch (FacebookOAuthException e) {
-      LOG.error("Caught Facebook OAuth error while getting user videos.", e);
-      return null;
-    }
-
-    JsonArray videoArray = videos.getJsonArray("data");
-    List<FacebookVideo> videoList = Lists.newArrayList();
-
-    for (int i = 0; i < videoArray.length() - 1; i++) {
-      JsonObject obj = videoArray.getJsonObject(i);
-      FacebookVideo vid = new FacebookVideo(obj.getString("id"), obj.getString("source"));
-      videoList.add(vid);
-    }
-
-    return videoList;
   }
 
   /**

--- a/application/src/test/java/com/sanction/lightning/resources/FacebookResourceTest.java
+++ b/application/src/test/java/com/sanction/lightning/resources/FacebookResourceTest.java
@@ -2,7 +2,6 @@ package com.sanction.lightning.resources;
 
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.Lists;
-import com.restfb.exception.FacebookOAuthException;
 import com.sanction.lightning.authentication.Key;
 import com.sanction.lightning.facebook.FacebookService;
 import com.sanction.lightning.facebook.FacebookServiceFactory;
@@ -92,7 +91,7 @@ public class FacebookResourceTest {
 
     Response response = resource.getUser(key, "Test", "password");
 
-    assertEquals(response.getStatusInfo(), Response.Status.INTERNAL_SERVER_ERROR);
+    assertEquals(response.getStatusInfo(), Response.Status.UNAUTHORIZED);
   }
 
   @Test
@@ -111,7 +110,7 @@ public class FacebookResourceTest {
   @Test
   @SuppressWarnings("unchecked")
   public void testGetUserWithExpiredOAuth() {
-    when(facebookService.getFacebookUser()).thenThrow(FacebookOAuthException.class);
+    when(facebookService.getFacebookUser()).thenReturn(null);
 
     Response response = resource.getUser(key, "Test", "password");
 
@@ -166,7 +165,7 @@ public class FacebookResourceTest {
 
     Response response = resource.getPhotos(key, "Test", "password");
 
-    assertEquals(response.getStatusInfo(), Response.Status.INTERNAL_SERVER_ERROR);
+    assertEquals(response.getStatusInfo(), Response.Status.UNAUTHORIZED);
   }
 
   @Test
@@ -184,8 +183,8 @@ public class FacebookResourceTest {
 
   @Test
   @SuppressWarnings("unchecked")
-  public void testGetPhotosWithOauthException() {
-    when(facebookService.getFacebookUserPhotos()).thenThrow(FacebookOAuthException.class);
+  public void testGetPhotosWithExpiredOauth() {
+    when(facebookService.getFacebookUserPhotos()).thenReturn(null);
 
     Response response = resource.getPhotos(key, "Test", "password");
 
@@ -241,7 +240,7 @@ public class FacebookResourceTest {
 
     Response response = resource.getVideos(key, "Test", "password");
 
-    assertEquals(response.getStatusInfo(), Response.Status.INTERNAL_SERVER_ERROR);
+    assertEquals(response.getStatusInfo(), Response.Status.UNAUTHORIZED);
   }
 
   @Test
@@ -259,8 +258,8 @@ public class FacebookResourceTest {
 
   @Test
   @SuppressWarnings("unchecked")
-  public void testGetVideosWithOauthException() {
-    when(facebookService.getFacebookUserVideos()).thenThrow(FacebookOAuthException.class);
+  public void testGetVideosWithExpiredOauth() {
+    when(facebookService.getFacebookUserVideos()).thenReturn(null);
 
     Response response = resource.getVideos(key, "Test", "password");
 
@@ -352,7 +351,7 @@ public class FacebookResourceTest {
     Response response = resource.publish(key, "Test", "password", PublishType.PHOTO,
         "Test", inputStream, contentDisposition, null);
 
-    assertEquals(response.getStatusInfo(), Response.Status.INTERNAL_SERVER_ERROR);
+    assertEquals(response.getStatusInfo(), Response.Status.UNAUTHORIZED);
   }
 
   @Test
@@ -473,7 +472,7 @@ public class FacebookResourceTest {
 
     Response response = resource.getExtendedToken(key, "Test", "password");
 
-    assertEquals(response.getStatusInfo(), Response.Status.INTERNAL_SERVER_ERROR);
+    assertEquals(response.getStatusInfo(), Response.Status.UNAUTHORIZED);
   }
 
   @Test
@@ -491,8 +490,8 @@ public class FacebookResourceTest {
 
   @Test
   @SuppressWarnings("unchecked")
-  public void testGetExtendedTokenWithOauthException() {
-    when(facebookService.getFacebookExtendedToken()).thenThrow(FacebookOAuthException.class);
+  public void testGetExtendedTokenWithExpiredOauth() {
+    when(facebookService.getFacebookExtendedToken()).thenReturn(null);
 
     Response response = resource.getExtendedToken(key, "Test", "password");
 
@@ -536,8 +535,8 @@ public class FacebookResourceTest {
 
   @Test
   @SuppressWarnings("unchecked")
-  public void testGetOauthUrlWithOauthException() {
-    when(facebookService.getOauthUrl(anyString())).thenThrow(FacebookOAuthException.class);
+  public void testGetOauthUrlWithExpiredOauth() {
+    when(facebookService.getOauthUrl(anyString())).thenReturn(null);
 
     Response response = resource.getOauthUrl(key, "example.com");
 


### PR DESCRIPTION
- Move `FacebookOAuthException` catches to `FacebookService.java` so that implementation details stay out of `FacebookResource.java`
- Better Thunder error handling when getting an `UNAUTHORIZED` response
- Only trigger Travis builds on `master`

Addresses #16 and #22 